### PR TITLE
UPP-903: Add filters for accessLevel field

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
@@ -71,7 +71,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
     private ApiFilter _unstable_stripOpeningXml;
     private ApiFilter linkValidationFilter;
     private ApiFilter mediaResourceNotificationsFilter;
-    private ApiFilter addAccessLevel;
+    private ApiFilter accessLevelFilter;
     private ApiFilter removeAccessFieldRegardlessOfPolicy;
 
     public static void main(final String[] args) throws Exception {
@@ -102,7 +102,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/notifications.*", "notifications", mediaResourceNotificationsFilter, brandFilter, stripNestedProvenance, stripNestedLastModifiedDate));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/enrichedcontent/.*", "enrichedcontent",
-                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml, addAccessLevel));
+                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml, accessLevelFilter));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists.*", "lists", stripProvenance, stripLastModifiedDate));
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists/notifications.*", "lists-notifications", stripNestedProvenance, stripNestedLastModifiedDate));
@@ -160,7 +160,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
         brandFilter = new AddBrandFilterParameters(jsonTweaker, resolver);
         linkValidationFilter = new LinkedContentValidationFilter();
         mediaResourceNotificationsFilter = new MediaResourceNotificationsFilter(jsonTweaker);
-        addAccessLevel = new RemoveJsonPropertyUnlessPolicyPresentFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY, Policy.INTERNAL_UNSTABLE);
+        accessLevelFilter = new RemoveJsonPropertyUnlessPolicyPresentFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY, Policy.INTERNAL_UNSTABLE);
         removeAccessFieldRegardlessOfPolicy = new SuppressJsonPropertyFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY);
     }
 

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
@@ -12,6 +12,7 @@ import com.ft.up.apipolicy.filters.AddSyndication;
 import com.ft.up.apipolicy.filters.LinkedContentValidationFilter;
 import com.ft.up.apipolicy.filters.MediaResourceNotificationsFilter;
 import com.ft.up.apipolicy.filters.PolicyBrandsResolver;
+import com.ft.up.apipolicy.filters.RemoveHeaderUnlessPolicyPresentFilter;
 import com.ft.up.apipolicy.filters.RemoveJsonPropertyFromArrayUnlessPolicyPresentFilter;
 import com.ft.up.apipolicy.filters.RemoveJsonPropertyUnlessPolicyPresentFilter;
 import com.ft.up.apipolicy.filters.SuppressJsonPropertyFilter;
@@ -52,6 +53,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
     private static final String LAST_MODIFIED_JSON_PROPERTY = "lastModified";
     private static final String OPENING_XML_JSON_PROPERTY = "openingXML";
     private static final String ACCESS_LEVEL_JSON_PROPERTY = "accessLevel";
+    private static final String ACCESS_LEVEL_HEADER = "X-FT-Access-Level";
 
     private ApiFilter mainImageFilter;
     private ApiFilter identifiersFilter;
@@ -71,8 +73,9 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
     private ApiFilter _unstable_stripOpeningXml;
     private ApiFilter linkValidationFilter;
     private ApiFilter mediaResourceNotificationsFilter;
-    private ApiFilter accessLevelFilter;
+    private ApiFilter accessLevelPropertyFilter;
     private ApiFilter removeAccessFieldRegardlessOfPolicy;
+    private ApiFilter accessLevelHeaderFilter;
 
     public static void main(final String[] args) throws Exception {
         new ApiPolicyApplication().run(args);
@@ -102,7 +105,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/notifications.*", "notifications", mediaResourceNotificationsFilter, brandFilter, stripNestedProvenance, stripNestedLastModifiedDate));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/enrichedcontent/.*", "enrichedcontent",
-                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml, accessLevelFilter));
+                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml, accessLevelPropertyFilter, accessLevelHeaderFilter));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists.*", "lists", stripProvenance, stripLastModifiedDate));
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists/notifications.*", "lists-notifications", stripNestedProvenance, stripNestedLastModifiedDate));
@@ -160,8 +163,9 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
         brandFilter = new AddBrandFilterParameters(jsonTweaker, resolver);
         linkValidationFilter = new LinkedContentValidationFilter();
         mediaResourceNotificationsFilter = new MediaResourceNotificationsFilter(jsonTweaker);
-        accessLevelFilter = new RemoveJsonPropertyUnlessPolicyPresentFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY, Policy.INTERNAL_UNSTABLE);
+        accessLevelPropertyFilter = new RemoveJsonPropertyUnlessPolicyPresentFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY, Policy.INTERNAL_UNSTABLE);
         removeAccessFieldRegardlessOfPolicy = new SuppressJsonPropertyFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY);
+        accessLevelHeaderFilter = new RemoveHeaderUnlessPolicyPresentFilter(ACCESS_LEVEL_HEADER, Policy.INTERNAL_UNSTABLE);
     }
 
     private KnownEndpoint createEndpoint(Environment environment, ApiPolicyConfiguration configuration,
@@ -169,8 +173,6 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
         final Client client = ResilientClientBuilder.in(environment).using(configuration.getVarnish()).named(instanceName).build();
 
         final RequestForwarder requestForwarder = new JerseyRequestForwarder(client, configuration.getVarnish());
-        final KnownEndpoint endpoint = new KnownEndpoint(urlPattern,
-                new HttpPipeline(requestForwarder, filterChain));
-        return endpoint;
+        return new KnownEndpoint(urlPattern, new HttpPipeline(requestForwarder, filterChain));
     }
 }

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
@@ -51,6 +51,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
     private static final String PROVENANCE_JSON_PROPERTY = "publishReference";
     private static final String LAST_MODIFIED_JSON_PROPERTY = "lastModified";
     private static final String OPENING_XML_JSON_PROPERTY = "openingXML";
+    private static final String ACCESS_LEVEL_JSON_PROPERTY = "accessLevel";
 
     private ApiFilter mainImageFilter;
     private ApiFilter identifiersFilter;
@@ -70,6 +71,8 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
     private ApiFilter _unstable_stripOpeningXml;
     private ApiFilter linkValidationFilter;
     private ApiFilter mediaResourceNotificationsFilter;
+    private ApiFilter addAccessLevel;
+    private ApiFilter removeAccessFieldRegardlessOfPolicy;
 
     public static void main(final String[] args) throws Exception {
         new ApiPolicyApplication().run(args);
@@ -91,15 +94,15 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
 
         //identifiersFilter needs to be added before webUrlAdder in the pipeline since webUrlAdder's logic is based on the json property that identifiersFilter might remove
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/.*", "content",
-                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, removeCommentsFieldRegardlessOfPolicy, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml));
+                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, removeCommentsFieldRegardlessOfPolicy, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml, removeAccessFieldRegardlessOfPolicy));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content-preview/.*", "content-preview",
-                identifiersFilter, webUrlAdder, addSyndication, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml));
+                identifiersFilter, webUrlAdder, addSyndication, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml, removeAccessFieldRegardlessOfPolicy));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/notifications.*", "notifications", mediaResourceNotificationsFilter, brandFilter, stripNestedProvenance, stripNestedLastModifiedDate));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/enrichedcontent/.*", "enrichedcontent",
-                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml));
+                identifiersFilter, webUrlAdder, addSyndication, linkValidationFilter, suppressMarkup, mainImageFilter, alternativeTitlesFilter, alternativeImagesFilter, alternativeStandfirstsFilter, stripCommentsFields, stripProvenance, stripLastModifiedDate, _unstable_stripOpeningXml, addAccessLevel));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists.*", "lists", stripProvenance, stripLastModifiedDate));
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists/notifications.*", "lists-notifications", stripNestedProvenance, stripNestedLastModifiedDate));
@@ -157,6 +160,8 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
         brandFilter = new AddBrandFilterParameters(jsonTweaker, resolver);
         linkValidationFilter = new LinkedContentValidationFilter();
         mediaResourceNotificationsFilter = new MediaResourceNotificationsFilter(jsonTweaker);
+        addAccessLevel = new RemoveJsonPropertyUnlessPolicyPresentFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY, Policy.INTERNAL_UNSTABLE);
+        removeAccessFieldRegardlessOfPolicy = new SuppressJsonPropertyFilter(jsonTweaker, ACCESS_LEVEL_JSON_PROPERTY);
     }
 
     private KnownEndpoint createEndpoint(Environment environment, ApiPolicyConfiguration configuration,

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/RemoveHeaderUnlessPolicyPresentFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/RemoveHeaderUnlessPolicyPresentFilter.java
@@ -1,0 +1,39 @@
+package com.ft.up.apipolicy.filters;
+
+import com.ft.up.apipolicy.configuration.Policy;
+import com.ft.up.apipolicy.pipeline.ApiFilter;
+import com.ft.up.apipolicy.pipeline.HttpPipelineChain;
+import com.ft.up.apipolicy.pipeline.MutableRequest;
+import com.ft.up.apipolicy.pipeline.MutableResponse;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+public class RemoveHeaderUnlessPolicyPresentFilter implements ApiFilter {
+
+    private final String header;
+    private final Policy policy;
+
+    public RemoveHeaderUnlessPolicyPresentFilter(String header, Policy policy) {
+        this.header = header;
+        this.policy = policy;
+    }
+
+    @Override
+    public MutableResponse processRequest(MutableRequest request, HttpPipelineChain chain) {
+        final MutableResponse response = chain.callNextFilter(request);
+        if (response.getStatus() != 200) {
+            return response;
+        }
+
+        MultivaluedMap<String, String> headers = response.getHeaders();
+        if (shouldFilterHeaderOut(request, response)) {
+            headers.remove(header);
+        }
+        return response;
+    }
+
+    private boolean shouldFilterHeaderOut(MutableRequest request, MutableResponse response) {
+        MultivaluedMap<String, String> headers = response.getHeaders();
+        return (!request.policyIs(policy) && headers.containsKey(header));
+    }
+}

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentHappyPathsTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentHappyPathsTest.java
@@ -57,6 +57,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
@@ -125,7 +126,8 @@ public class ApiPolicyComponentHappyPathsTest extends AbstractApiComponentTest {
                     "\"authority\": \"http://www.ft.com/ontology/origin/FT-CLAMO\",\n" +
                     "\"identifierValue\": \"220322\"\n" +
                     "}],\n" +
-                    "\"canBeSyndicated\": \"no\"" +
+                    "\"canBeSyndicated\": \"no\",\n" +
+                    "\"accessLevel\":\"subscribed\"\n" +
                     "}";
     private static final String ENRICHED_CONTENT_JSON =
             "{" +
@@ -141,7 +143,8 @@ public class ApiPolicyComponentHappyPathsTest extends AbstractApiComponentTest {
                     "\"identifierValue\": \"220322\"\n" +
                     "}]," +
                     "\"brands\": [ ],\n" +
-                    "\"annotations\": [ ]" +
+                    "\"annotations\": [ ], \n" +
+                    "\"accessLevel\": \"subscribed\"\n" +
                     "}";
     private static final String RICH_CONTENT_JSON = "{" +
             "\"uuid\": \"bcafca32-5bc7-343f-851f-fd6d3514e694\", " +
@@ -909,6 +912,48 @@ public class ApiPolicyComponentHappyPathsTest extends AbstractApiComponentTest {
                 .get(ClientResponse.class);
         try {
             assertThat(response.getStatus(), equalTo(301));
+        } finally {
+            response.close();
+        }
+    }
+
+    @Test
+    public void givenPolicyINTERNAL_UNSTABLEShouldReturnAccessLevelForEnrichedContent () throws IOException {
+        givenEverythingSetup();
+
+        stubFor(get(urlPathEqualTo(ENRICHED_CONTENT_PATH))
+                .willReturn(aResponse().withBody(ENRICHED_CONTENT_JSON).withHeader("Content-Type", MediaType.APPLICATION_JSON).withStatus(200)));
+
+        URI uri = fromFacade(ENRICHED_CONTENT_PATH).build();
+
+        ClientResponse response = client
+                .resource(uri)
+                .header(HttpPipeline.POLICY_HEADER_NAME, Policy.INTERNAL_UNSTABLE.getHeaderValue())
+                .get(ClientResponse.class);
+
+        try {
+            verify(getRequestedFor(urlPathEqualTo(ENRICHED_CONTENT_PATH)));
+
+            Map<String, Object> result = expectOKResponseWithJSON(response);
+            assertEquals(result.get("accessLevel"), "subscribed");
+
+        } finally {
+            response.close();
+        }
+    }
+
+    @Test
+    public void givenAnyPolicyShouldNotGetAccessLevelFieldForContent() throws IOException {
+        givenEverythingSetup();
+        URI uri  = fromFacade(CONTENT_PATH_3).build();
+        ClientResponse response = client
+                .resource(uri)
+                .header(HttpPipeline.POLICY_HEADER_NAME, Policy.INTERNAL_UNSTABLE.getHeaderValue())
+                .get(ClientResponse.class);
+        try {
+            verify(getRequestedFor(urlEqualTo(CONTENT_PATH_3)));
+            Map<String, Object> result = expectOKResponseWithJSON(response);
+            assertFalse(result.containsKey("accessLevel"));
         } finally {
             response.close();
         }

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/RemoveHeaderUnlessPolicyPresentFilterTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/RemoveHeaderUnlessPolicyPresentFilterTest.java
@@ -1,0 +1,108 @@
+package com.ft.up.apipolicy.filters;
+
+import com.ft.up.apipolicy.configuration.Policy;
+import com.ft.up.apipolicy.pipeline.HttpPipelineChain;
+import com.ft.up.apipolicy.pipeline.MutableRequest;
+import com.ft.up.apipolicy.pipeline.MutableResponse;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+
+import static com.ft.up.apipolicy.configuration.Policy.INTERNAL_UNSTABLE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RemoveHeaderUnlessPolicyPresentFilterTest {
+
+    private static final String ACCESS_LEVEL_HEADER = "X-FT-Access-Level";
+
+    private RemoveHeaderUnlessPolicyPresentFilter removeHeaderUnlessPolicyPresentFilter;
+
+    @Before
+    public void setUp() {
+        removeHeaderUnlessPolicyPresentFilter = new RemoveHeaderUnlessPolicyPresentFilter(ACCESS_LEVEL_HEADER, Policy.INTERNAL_UNSTABLE);
+    }
+
+    @Test
+    public void testFiltersHeader() throws Exception {
+        final MutableRequest mockedRequest = mock(MutableRequest.class);
+        final HttpPipelineChain mockedChain = mock(HttpPipelineChain.class);
+        final MultivaluedMap<String, String> headers = new MultivaluedMapImpl();
+        headers.add("Content-Type", MediaType.APPLICATION_JSON);
+        headers.add(ACCESS_LEVEL_HEADER, "subscribed");
+        final MutableResponse initialResponse = new MutableResponse(headers, new byte[0]);
+        initialResponse.setStatus(200);
+        when(mockedChain.callNextFilter(mockedRequest)).thenReturn(initialResponse);
+
+        final MutableResponse processedResponse = removeHeaderUnlessPolicyPresentFilter.processRequest(mockedRequest, mockedChain);
+
+        assertNull(processedResponse.getHeaders().getFirst(ACCESS_LEVEL_HEADER));
+    }
+
+    @Test
+    public void testLeavesHeaderWhenPolicyHeaderSet() throws Exception {
+        final MutableRequest mockedRequest = mock(MutableRequest.class);
+        when(mockedRequest.policyIs(INTERNAL_UNSTABLE)).thenReturn(true);
+        final HttpPipelineChain mockedChain = mock(HttpPipelineChain.class);
+        final MultivaluedMap<String, String> headers = new MultivaluedMapImpl();
+        headers.add("Content-Type", MediaType.APPLICATION_JSON);
+        headers.add(ACCESS_LEVEL_HEADER, "subscribed");
+        final MutableResponse initialResponse = new MutableResponse(headers, new byte[0]);
+        initialResponse.setStatus(200);
+        when(mockedChain.callNextFilter(mockedRequest)).thenReturn(initialResponse);
+
+        final MutableResponse processedResponse = removeHeaderUnlessPolicyPresentFilter.processRequest(mockedRequest, mockedChain);
+
+        assertEquals(processedResponse.getHeaders().getFirst(ACCESS_LEVEL_HEADER), "subscribed");
+    }
+
+    @Test
+    public void testDoesNotTouchWhenHeaderIsAbsent() throws Exception {
+        final MutableRequest mockedRequest = mock(MutableRequest.class);
+        final HttpPipelineChain mockedChain = mock(HttpPipelineChain.class);
+        final MultivaluedMap<String, String> headers = new MultivaluedMapImpl();
+        headers.add("Content-Type", MediaType.APPLICATION_JSON);
+        final MutableResponse initialResponse = new MutableResponse(headers, new byte[0]);
+        initialResponse.setStatus(200);
+        final MutableResponse spiedResponse = spy(initialResponse);
+        when(mockedChain.callNextFilter(mockedRequest)).thenReturn(spiedResponse);
+
+        removeHeaderUnlessPolicyPresentFilter.processRequest(mockedRequest, mockedChain);
+
+        verifyResponseNotMutated(spiedResponse);
+    }
+
+    @Test
+    public void testLeavesEverythingWhenNot200() throws Exception {
+        final MutableRequest mockedRequest = mock(MutableRequest.class);
+        final HttpPipelineChain mockedChain = mock(HttpPipelineChain.class);
+        final MutableResponse mockedResponse = mock(MutableResponse.class);
+        when(mockedResponse.getStatus()).thenReturn(422);
+        when(mockedChain.callNextFilter(mockedRequest)).thenReturn(mockedResponse);
+
+        removeHeaderUnlessPolicyPresentFilter.processRequest(mockedRequest, mockedChain);
+
+        verifyResponseNotMutated(mockedResponse);
+    }
+
+    public void verifyResponseNotMutated(final MutableResponse mockedResponse) {
+        verify(mockedResponse, never()).setEntity(Mockito.any(byte[].class));
+        verify(mockedResponse, never()).setHeaders(Mockito.any(MultivaluedMap.class));
+        verify(mockedResponse, never()).setStatus(anyInt());
+    }
+
+
+}


### PR DESCRIPTION
This field should be present for /enrichedcontent and hidden for other endpoints