### PR TITLE
Correct webUrl for videos with NEXT-VIDEO-EDITOR authority

### DIFF
--- a/api-policy-component-service/config-local.yml
+++ b/api-policy-component-service/config-local.yml
@@ -20,6 +20,7 @@ pipeline:
     "http://api.ft.com/system/FT-CLAMO"  : "http://www.ft.com/fastft?post={{identifierValue}}"
     "http://api.ft.com/system/FT-LABS-WP-1-[0-9]+" : "{{identifierValue}}"
     "http://api.ft.com/system/BRIGHTCOVE" : "http://video.ft.com/{{identifierValue}}"
+    "http://api.ft.com/system/NEXT-VIDEO-EDITOR" : "https://www.ft.com/video/{{identifierValue}}"
 
 
 policyBrandsMapper:

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/WebUrlCalculator.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/WebUrlCalculator.java
@@ -23,6 +23,7 @@ public class WebUrlCalculator implements ApiFilter {
     private static final String IDENTIFIERS_KEY = "identifiers";
     private static final String AUTHORITY_KEY = "authority";
     private static final String BRIGHTCOVE_AUTHORITY = "http://api.ft.com/system/BRIGHTCOVE";
+    private static final String NEXT_VIDEO_EDITOR_AUTHORITY = "http://api.ft.com/system/NEXT-VIDEO-EDITOR";
 
     private static final String ARTICLE_TYPE = "http://www.ft.com/ontology/content/Article";
     private static final String MEDIA_RESOURCE_TYPE = "http://www.ft.com/ontology/content/MediaResource";
@@ -74,7 +75,7 @@ public class WebUrlCalculator implements ApiFilter {
                         Map identifier = ((Map) identifierRaw);
                         if (identifier.containsKey(AUTHORITY_KEY)) {
                             final Object authority = identifier.get(AUTHORITY_KEY);
-                            if (BRIGHTCOVE_AUTHORITY.equals(authority)) {
+                            if (BRIGHTCOVE_AUTHORITY.equals(authority) || NEXT_VIDEO_EDITOR_AUTHORITY.equals(authority)) {
                                 return true;
                             }
                         }


### PR DESCRIPTION
The field should look like this: `"webUrl": "https://www.ft.com/video/a40808ac-1417-4c48-9781-1dd2d8c8c6dc"`
Also still supporting videos with BRIGHTCOVE authority.

See also  https://sites.google.com/a/ft.com/universal-publishing/documentation/story-specs/3-mar-2017-next-video-platform-work for architecture diagram and other useful information