### PR TITLE
Adding support for public-annotations-api.

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
@@ -120,6 +120,9 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
                 removeAccessFieldRegardlessOfPolicy,
                 syndicationDistributionFilter));
 
+        // no filters needed for public-annotations-api
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/annotations", "public-annotations-api", new ApiFilter[]{}));
+
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content-preview/.*", "content-preview",
                 identifiersFilter,
                 webUrlAdder,
@@ -135,7 +138,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
                 stripLastModifiedDate,
                 stripOpeningXml,
                 removeAccessFieldRegardlessOfPolicy,
-				expandedImagesFilter));
+                expandedImagesFilter));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/notifications.*", "notifications",
                 mediaResourceNotificationsFilter,
@@ -180,7 +183,7 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
                 accessLevelHeaderFilter,
                 syndicationDistributionFilter,
                 contentPackageFilter,
-				expandedImagesFilter));
+                expandedImagesFilter));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/internalcontent-preview/.*", "internalcontent-preview",
                 identifiersFilter,

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
@@ -9,7 +9,20 @@ import com.ft.platform.dropwizard.DefaultGoodToGoChecker;
 import com.ft.platform.dropwizard.GoodToGoBundle;
 import com.ft.up.apipolicy.configuration.ApiPolicyConfiguration;
 import com.ft.up.apipolicy.configuration.Policy;
-import com.ft.up.apipolicy.filters.*;
+import com.ft.up.apipolicy.filters.AddBrandFilterParameters;
+import com.ft.up.apipolicy.filters.AddSyndication;
+import com.ft.up.apipolicy.filters.ExpandedImagesFilter;
+import com.ft.up.apipolicy.filters.LinkedContentValidationFilter;
+import com.ft.up.apipolicy.filters.NotificationsTypeFilter;
+import com.ft.up.apipolicy.filters.PolicyBasedJsonFilter;
+import com.ft.up.apipolicy.filters.PolicyBrandsResolver;
+import com.ft.up.apipolicy.filters.RemoveHeaderUnlessPolicyPresentFilter;
+import com.ft.up.apipolicy.filters.RemoveJsonPropertiesUnlessPolicyPresentFilter;
+import com.ft.up.apipolicy.filters.SuppressInternalContentFilter;
+import com.ft.up.apipolicy.filters.SuppressJsonPropertiesFilter;
+import com.ft.up.apipolicy.filters.SuppressRichContentMarkupFilter;
+import com.ft.up.apipolicy.filters.SyndicationDistributionFilter;
+import com.ft.up.apipolicy.filters.WebUrlCalculator;
 import com.ft.up.apipolicy.health.ReaderNodesHealthCheck;
 import com.ft.up.apipolicy.pipeline.ApiFilter;
 import com.ft.up.apipolicy.pipeline.HttpPipeline;
@@ -21,17 +34,20 @@ import com.ft.up.apipolicy.resources.WildcardEndpointResource;
 import com.ft.up.apipolicy.transformer.BodyPostProcessingFieldTransformerFactory;
 import com.ft.up.apipolicy.transformer.BodyProcessingFieldTransformer;
 import com.ft.up.apipolicy.transformer.BodyProcessingFieldTransformerFactory;
+
 import com.sun.jersey.api.client.Client;
+
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.DispatcherType;
+
 import io.dropwizard.Application;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
-
-import javax.servlet.DispatcherType;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import static com.ft.up.apipolicy.configuration.Policy.EXPAND_RICH_CONTENT;
 import static com.ft.up.apipolicy.configuration.Policy.INCLUDE_COMMENTS;
@@ -98,73 +114,16 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
         environment.jersey().register(new RuntimeExceptionMapper());
         setFilters(configuration, environment);
 
-        SortedSet<KnownEndpoint> knownWildcardEndpoints = new TreeSet<>();
-        SortedSet<KnownEndpoint> knownWhitelistedPostEndpoints = new TreeSet<>();
+        Set<KnownEndpoint> knownWildcardEndpoints = new LinkedHashSet<>();
+        Set<KnownEndpoint> knownWhitelistedPostEndpoints = new LinkedHashSet<>();
 
-        //identifiersFilter needs to be added before webUrlAdder in the pipeline since webUrlAdder's logic is based on the json property that identifiersFilter might remove
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/.*", "content",
-                identifiersFilter,
-                webUrlAdder,
-                addSyndication,
-                linkValidationFilter,
-                suppressMarkup,
-                suppressInternalContent,
-                mainImageFilter,
-                alternativeTitlesFilter,
-                alternativeImagesFilter,
-                alternativeStandfirstsFilter,
-                removeCommentsFieldRegardlessOfPolicy,
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/things.*", "things", new ApiFilter[]{}));
+
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists/notifications.*", "lists-notifications", notificationsFilter()));
+
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists.*", "lists",
                 stripProvenance,
-                stripLastModifiedDate,
-                stripOpeningXml,
-                removeAccessFieldRegardlessOfPolicy,
-                syndicationDistributionFilter));
-
-        // no filters needed for public-annotations-api
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/annotations", "public-annotations-api", new ApiFilter[]{}));
-
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content-preview/.*", "content-preview",
-                identifiersFilter,
-                webUrlAdder,
-                addSyndication,
-                suppressMarkup,
-                suppressInternalContent,
-                mainImageFilter,
-                alternativeTitlesFilter,
-                alternativeImagesFilter,
-                alternativeStandfirstsFilter,
-                stripCommentsFields,
-                stripProvenance,
-                stripLastModifiedDate,
-                stripOpeningXml,
-                removeAccessFieldRegardlessOfPolicy,
-                expandedImagesFilter));
-
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/notifications.*", "notifications",
-                mediaResourceNotificationsFilter,
-                brandFilter,
-                notificationsFilter()));
-
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/enrichedcontent/.*", "enrichedcontent",
-                identifiersFilter,
-                webUrlAdder,
-                addSyndication,
-                linkValidationFilter,
-                suppressMarkup,
-                suppressInternalContent,
-                mainImageFilter,
-                alternativeTitlesFilter,
-                alternativeImagesFilter,
-                alternativeStandfirstsFilter,
-                stripCommentsFields,
-                stripProvenance,
-                stripLastModifiedDate,
-                stripOpeningXml,
-                accessLevelPropertyFilter,
-                accessLevelHeaderFilter,
-                syndicationDistributionFilter,
-                contentPackageFilter,
-                expandedImagesFilter));
+                stripLastModifiedDate));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/internalcontent/.*", "internalcontent",
                 identifiersFilter,
@@ -200,15 +159,72 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
                 removeAccessFieldRegardlessOfPolicy,
                 expandedImagesFilter));
 
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists.*", "lists",
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/enrichedcontent/.*", "enrichedcontent",
+                identifiersFilter,
+                webUrlAdder,
+                addSyndication,
+                linkValidationFilter,
+                suppressMarkup,
+                suppressInternalContent,
+                mainImageFilter,
+                alternativeTitlesFilter,
+                alternativeImagesFilter,
+                alternativeStandfirstsFilter,
+                stripCommentsFields,
                 stripProvenance,
-                stripLastModifiedDate));
+                stripLastModifiedDate,
+                stripOpeningXml,
+                accessLevelPropertyFilter,
+                accessLevelHeaderFilter,
+                syndicationDistributionFilter,
+                contentPackageFilter,
+                expandedImagesFilter));
 
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/lists/notifications.*", "lists-notifications", notificationsFilter()));
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/notifications.*", "notifications",
+                mediaResourceNotificationsFilter,
+                brandFilter,
+                notificationsFilter()));
+
+        // no filters needed for public-annotations-api
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/annotations", "public-annotations-api", new ApiFilter[]{}));
+
+        //identifiersFilter needs to be added before webUrlAdder in the pipeline since webUrlAdder's logic is based on the json property that identifiersFilter might remove
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content/.*", "content",
+                identifiersFilter,
+                webUrlAdder,
+                addSyndication,
+                linkValidationFilter,
+                suppressMarkup,
+                suppressInternalContent,
+                mainImageFilter,
+                alternativeTitlesFilter,
+                alternativeImagesFilter,
+                alternativeStandfirstsFilter,
+                removeCommentsFieldRegardlessOfPolicy,
+                stripProvenance,
+                stripLastModifiedDate,
+                stripOpeningXml,
+                removeAccessFieldRegardlessOfPolicy,
+                syndicationDistributionFilter));
+
+        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/content-preview/.*", "content-preview",
+                identifiersFilter,
+                webUrlAdder,
+                addSyndication,
+                suppressMarkup,
+                suppressInternalContent,
+                mainImageFilter,
+                alternativeTitlesFilter,
+                alternativeImagesFilter,
+                alternativeStandfirstsFilter,
+                stripCommentsFields,
+                stripProvenance,
+                stripLastModifiedDate,
+                stripOpeningXml,
+                removeAccessFieldRegardlessOfPolicy,
+                expandedImagesFilter));
 
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/concordances.*", "concordances", new ApiFilter[]{}));
-
-        knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/things.*", "things", new ApiFilter[]{}));
 
         // DEFAULT CASE: Just forward it
         knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/.*", "other", new ApiFilter[]{}));

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/JsonConverter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/JsonConverter.java
@@ -22,8 +22,8 @@ public class JsonConverter {
         return new JsonConverter(new ObjectMapper());
     }
 
-    public static final TypeReference<LinkedHashMap<String,Object>> JSON_MAP_TYPE = new TypeReference<LinkedHashMap<String, Object>>() {
-    };
+    public static final TypeReference<LinkedHashMap<String,Object>> JSON_MAP_TYPE = new TypeReference<LinkedHashMap<String, Object>>() {};
+    public static final TypeReference<LinkedHashMap<String,Object>[]> JSON_ARRAY_TYPE = new TypeReference<LinkedHashMap<String, Object>[]>() {};
     private final ObjectMapper objectMapper;
 
     public JsonConverter(ObjectMapper objectMapper) {

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/resources/RequestHandler.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/resources/RequestHandler.java
@@ -30,9 +30,9 @@ public class RequestHandler {
     public static final Joiner COMMA_DELIMITED = Joiner.on(", ");
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestHandler.class);
     private MutableHttpTranslator translator;
-    private SortedSet<KnownEndpoint> knownEndpoints;
+    private Set<KnownEndpoint> knownEndpoints;
 
-    public RequestHandler(MutableHttpTranslator translator, SortedSet<KnownEndpoint> knownEndpoints) {
+    public RequestHandler(MutableHttpTranslator translator, Set<KnownEndpoint> knownEndpoints) {
         this.translator = translator;
         this.knownEndpoints = knownEndpoints;
     }
@@ -70,7 +70,6 @@ public class RequestHandler {
 
     private MutableResponse handleRequest(MutableRequest request, String path) {
         for (KnownEndpoint candidate : knownEndpoints) {
-
             Pattern compiledUriRegex = candidate.getUriPattern();
 
             Matcher matcher = compiledUriRegex.matcher(path);


### PR DESCRIPTION
No filtering performed on the request, so all that's added is a regex after the /content.* regex.