### PR TITLE
Don't add canBeSyndicated to mainImage if the content is not unrolled

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/AbstractImageFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/AbstractImageFilter.java
@@ -15,7 +15,7 @@ public abstract class AbstractImageFilter implements ApiFilter {
         Object mainImageSet = content.get(MAIN_IMAGE);
         if (mainImageSet instanceof Map) {
             Map mainImageSetAsMap = (Map) mainImageSet;
-            if (mainImageSetAsMap.size() > 1) {
+            if (mainImageSetAsMap.size() > 2) {
                 try {
                     applyFilterToFromImageSet(jsonProperty, modifier, mainImageSetAsMap);
                 } catch (WebApplicationClientException e) {

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/CanBeDistributedAccessFilterTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/CanBeDistributedAccessFilterTest.java
@@ -113,8 +113,8 @@ public class CanBeDistributedAccessFilterTest {
 
     @Test
     public void shouldStripNestedImageWhenNotPolicyAndCanBeDistributedFieldNotYesForNestedImageContent() {
-        MutableRequest request = new MutableRequest(Collections.<String>emptySet(), getClass().getSimpleName());
-        MutableResponse chainedResponse = createSuccessfulResponse("{\"bodyXML\":\"<body>Testing.</body>\",\"canBeDistributed\":\"yes\",\"mainImage\":{\"id\":\"sampleId\",\"canBeDistributed\":\"verify\"}}");
+        MutableRequest request = new MutableRequest(Collections.emptySet(), getClass().getSimpleName());
+        MutableResponse chainedResponse = createSuccessfulResponse("{\"bodyXML\":\"<body>Testing.</body>\",\"canBeDistributed\":\"yes\",\"mainImage\":{\"id\":\"sampleId\",\"apiUrl\":\"sampleApiUrl\",\"canBeDistributed\":\"verify\"}}");
 
         when(mockChain.callNextFilter(request)).thenReturn(chainedResponse);
 

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/CanBeSyndicatedAccessFilterTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/CanBeSyndicatedAccessFilterTest.java
@@ -104,7 +104,7 @@ public class CanBeSyndicatedAccessFilterTest {
         final Set<String> policies = new HashSet<>();
         policies.add(Policy.RESTRICT_NON_SYNDICATABLE_CONTENT.getHeaderValue());
         final MutableRequest request = new MutableRequest(policies, getClass().getSimpleName());
-        MutableResponse chainedResponse = createSuccessfulResponse("{\"bodyXML\":\"<body>Testing.</body>\",\"canBeSyndicated\":\"yes\",\"mainImage\":{\"id\":\"sampleId\",\"canBeSyndicated\":\"verify\"}}");
+        MutableResponse chainedResponse = createSuccessfulResponse("{\"bodyXML\":\"<body>Testing.</body>\",\"canBeSyndicated\":\"yes\",\"mainImage\":{\"id\":\"sampleId\",\"apiUrl\":\"sampleApiUrl\",\"canBeSyndicated\":\"verify\"}}");
 
         when(mockChain.callNextFilter(request)).thenReturn(chainedResponse);
 


### PR DESCRIPTION
This PR is part of a bigger story.

Given a Content with uuid A, the top level id should be `http://www.ft.com/thing/A`

The embeds, mainImage and leadImages
- apiUrl is `https://api.ft.com/{endpoint}/A`
- the id should be the same as its top level id: `http://www.ft.com/thing/A`

The apiUrl from the mainImage, leadImages and embeds fields will contain the value of the requestUrl that is returned by content-public-read.

This modification requires some changes to be made by the Next team (the people who are responsible for ft.com). Do not merge this PR if those changes haven't been implemented. Make sure you talk to @davidlintonattheft before trying to merge this.

PRs related to this story:
https://github.com/Financial-Times/content-public-read/pull/35
https://github.com/Financial-Times/enriched-content-read-api/pull/13
https://github.com/Financial-Times/internal-content-api/pull/28
https://github.com/Financial-Times/content-unroller/pull/14
https://github.com/Financial-Times/unrolled-content-public-read/pull/4