### PR TITLE
Allow specifying additional content types for /content/notifications 

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
@@ -9,7 +9,6 @@ import com.ft.up.apipolicy.pipeline.MutableResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 
 public class NotificationsTypeFilter implements ApiFilter {
@@ -56,21 +55,13 @@ public class NotificationsTypeFilter implements ApiFilter {
 
   private void addQueryParams(MutableRequest request) {
 
-    List<String> typeParams = new ArrayList<>();
     if (request.policyIs(policy)) {
-      MultivaluedMap<String, String> queryParameters = request.getQueryParameters();
-      if (queryParameters.containsKey("type")) {
-        List<String> typeValues = queryParameters.get("type");
-        for (String v : typeValues) {
-          typeParams.add(v);
-        }
-      }
-
-      typeParams.add("all");
+      request.getQueryParameters().add(TYPE_KEY, "all");
     } else {
+      List<String> typeParams = new ArrayList<>();
       typeParams.add("article");
+      request.getQueryParameters().put(TYPE_KEY, typeParams);
     }
-    request.getQueryParameters().put(TYPE_KEY, typeParams);
   }
 
   private void stripTypeParam(Map<String, Object> content, String key) {

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
@@ -9,6 +9,7 @@ import com.ft.up.apipolicy.pipeline.MutableResponse;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriBuilder;
 
 public class NotificationsTypeFilter implements ApiFilter {
@@ -57,6 +58,14 @@ public class NotificationsTypeFilter implements ApiFilter {
 
     List<String> typeParams = new ArrayList<>();
     if (request.policyIs(policy)) {
+      MultivaluedMap<String, String> queryParameters = request.getQueryParameters();
+      if (queryParameters.containsKey("type")) {
+        List<String> typeValues = queryParameters.get("type");
+        for (String v : typeValues) {
+          typeParams.add(v);
+        }
+      }
+
       typeParams.add("all");
     } else {
       typeParams.add("article");


### PR DESCRIPTION
# Description

## What

Allow specifying additional content types for /content/notifications (like LiveBlogPost & LiveBlogPackage) when using INTERNAL_UNSTABLE policy

## Why

We would like to allow internal customers when subscribing for notifications to specify if they want to receive notifications for live blogs or not. 
## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
