### PR TITLE
Apply policy based filtering for e2e capability tests for Pull notifications

### DIFF
--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,12 @@
+FROM openjdk:8u212-jdk-alpine3.9
+
+RUN apk update && apk upgrade
+ENV MAVEN_HOME=/root/.m2
+RUN apk add maven curl
+
+RUN mkdir $MAVEN_HOME \
+    && curl -v -o /root/.m2/settings.xml "https://raw.githubusercontent.com/Financial-Times/nexus-settings/master/public-settings.xml"
+
+
+COPY . /api-policy-component/
+WORKDIR /api-policy-component

--- a/README.markdown
+++ b/README.markdown
@@ -43,7 +43,7 @@ Note that one policy might be used by many filters and filters might work with m
 | unrolledContentFilter                 | Adds `unrollContent=true` to the request query if the INCLUDE_RICH_CONTENT and EXPAND_RICH_CONTENT policies are present                                                                                             | /content-preview, /internalcontent-preview, /enrichedcontent, /internalcontent                   |
 | stripCommentsFields                   | Removes the `comments` field from the response unless the INCLUDE_COMMENTS policy is present                                                                                                                       | /content-preview, /internalcontent-preview, /enrichedcontent, /internalcontent                   |
 | brandFilter                           | Adds `forBrand=XXX` to the request query if FASTFT_CONTENT_ONLY policy is present or adds `notForBrand=XXX` to the request query if EXCLUDE_FASTFT_CONTENT policy is present, where XXX is the brand id for FastFT | /content/notifications                                                                           |
-| mediaResourceNotificationsFilter      | Adds `type=all` to the request query if the INTERNAL_UNSTABLE policy is present, otherwise adds `type=article`                                                                                                     | /content/notifications                                                                           |
+| mediaResourceNotificationsFilter      | Adds `type=all` and `monitor=true` to the request query if the INTERNAL_UNSTABLE policy is present, otherwise adds `type=article` and `monitor=false`                                                                                                    | /content/notifications                                                                           |
 | accessLevelPropertyFilter             | Removes the `accessLevel` field from the response unless the INTERNAL_UNSTABLE policy is present                                                                                                                   | /enrichedcontent, /internalcontent                                                               |
 | accessLevelHeaderFilter               | Removes the `X-FT-Access-Level` header from the response unless the INTERNAL_UNSTABLE policy is present                                                                                                            | /enrichedcontent, /internalcontent                                                               |
 | contentPackageFilter                  | Removes the `contains` and `containedIn` fields from the response unless the INTERNAL_UNSTABLE policy is present                                                                                                   | /enrichedcontent, /internalcontent                                                               |
@@ -110,3 +110,18 @@ Building with docker:
 Running as a docker container:
 
 ```docker run --rm -p 8080 -p 8081 --env "JAVA_OPTS=-Xms384m -Xmx384m -XX:+UseG1GC -server" --env "READ_ENDPOINT=localhost:8080:8080" --env "JERSEY_TIMEOUT_DURATION=10000ms" coco/api-policy-component:your-version```
+
+## Running all tests using Docker Compose
+- Set the following environment variables (get the values from LastPass) so that Maven will be able to fetch all needed dependencies:
+    ```
+    export SONATYPE_USER="xxx"
+    export SONATYPE_PASSWORD="xxx"
+    ```
+- Run the standard triplet of Docker/Compose commands:
+    ```
+    docker-compose -f docker-compose-tests.yml up -d --build && \
+    docker logs -f test-runner && \
+    docker-compose -f docker-compose-tests.yml down -v
+    ```
+
+**Note**: The `docker-compose-tests.yml` file is set to mount the standard directory used for the local Maven repository (`~/.m2/repository`) into the `test-runner` container, but if you have not used Maven before you can set it to any other directory on your system.

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
@@ -55,12 +55,15 @@ public class NotificationsTypeFilter implements ApiFilter {
 
   private void addQueryParams(MutableRequest request) {
     List<String> typeParams = new ArrayList<>();
-    if (request.policyIs(policy)) {
+    boolean hasRequiredPolicy = request.policyIs(policy);
+    if (hasRequiredPolicy) {
       typeParams.add("all");
     } else {
       typeParams.add("article");
     }
+
     request.getQueryParameters().put(TYPE_KEY, typeParams);
+    request.getQueryParameters().putSingle("monitor", String.valueOf(hasRequiredPolicy));
   }
 
   private void stripTypeParam(Map<String, Object> content, String key) {

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
@@ -3,8 +3,10 @@ package com.ft.up.apipolicy.filters;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -31,7 +33,11 @@ public class NotificationsTypeFilterTest {
 
   public static final String ERROR_RESPONSE = "{ \"message\" : \"Error\" }";
   public static final String SUCCESS_RESPONSE =
-      "{ \"requestUrl\": \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\", \"links\": [ {\"href\": \"http://example.org/content/100?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\", \"rel\" : \"next\"}] }";
+      "{ \"requestUrl\":"
+          + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\","
+          + " \"links\": [ {\"href\":"
+          + " \"http://example.org/content/100?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\","
+          + " \"rel\" : \"next\"}] }";
   public static final String STRIPPED_SUCCESS_RESPONSE =
       "{\"requestUrl\":\"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z\",\"links\":[{\"href\":\"http://example.org/content/100?since=2016-07-23T00:00:00.000Z\",\"rel\":\"next\"}]}";
 
@@ -102,6 +108,43 @@ public class NotificationsTypeFilterTest {
   }
 
   @Test
+  public void testThatMonitorQueryParamIsSetToTrueWhenPolicyIsPresent() {
+    when(request.policyIs(Policy.INTERNAL_UNSTABLE)).thenReturn(true);
+    MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+    when(request.getQueryParameters()).thenReturn(params);
+    when(chain.callNextFilter(request)).thenReturn(successResponse);
+
+    filter.processRequest(request, chain);
+
+    verify(params).putSingle("monitor", "true");
+  }
+
+  @Test
+  public void testThatMonitorQueryParamIsSetToFalseWhenPolicyIsNotPresent() {
+    when(request.policyIs(Policy.INTERNAL_UNSTABLE)).thenReturn(false);
+    MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
+    when(request.getQueryParameters()).thenReturn(params);
+    when(chain.callNextFilter(request)).thenReturn(successResponse);
+
+    filter.processRequest(request, chain);
+
+    verify(params).putSingle("monitor", "false");
+  }
+
+  @Test
+  public void testThatMonitorQueryParamCannotOverwritePolicyRestriction() {
+    when(request.policyIs(Policy.INTERNAL_UNSTABLE)).thenReturn(false);
+    MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+    params.putSingle("monitor", "true");
+    when(request.getQueryParameters()).thenReturn(params);
+    when(chain.callNextFilter(request)).thenReturn(successResponse);
+
+    filter.processRequest(request, chain);
+
+    assertEquals("false", params.getFirst("monitor"));
+  }
+
+  @Test
   public void testThatForNon200ResponseNoOtherInteractionHappens() {
     when(request.policyIs(Policy.INTERNAL_UNSTABLE)).thenReturn(true);
     MultivaluedMap<String, String> params = mock(MultivaluedMap.class);
@@ -111,7 +154,7 @@ public class NotificationsTypeFilterTest {
     filter.processRequest(request, chain);
 
     verify(request).policyIs(Policy.INTERNAL_UNSTABLE);
-    verify(request).getQueryParameters();
+    verify(request, times(2)).getQueryParameters();
     verifyNoMoreInteractions(request);
   }
 
@@ -135,7 +178,9 @@ public class NotificationsTypeFilterTest {
     when(request.getQueryParameters()).thenReturn(params);
 
     String responseBody =
-        "{ \"requestUrl\": \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\", \"links\": [] }";
+        "{ \"requestUrl\":"
+            + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\","
+            + " \"links\": [] }";
     String strippedBody =
         "{\"requestUrl\":\"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z\",\"links\":[]}";
     MutableResponse responseWithEmptyLinksArray =

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile.tests
+    container_name: test-runner
+    environment:
+      SONATYPE_USER: ${SONATYPE_USER}
+      SONATYPE_PASSWORD: ${SONATYPE_PASSWORD}
+    volumes:
+      - ~/.m2/repository:/root/.m2/repository
+    command: ["mvn", "test"]


### PR DESCRIPTION
# Description

## What

Modify the current `mediaResourceNotificationsFilter` to set `monitor` query parameter when proxying requests to `notifications-rw` service based on the configured (INTERNAL_UNSTABLE) policy.
This is needed so that requests coming to our public endpoint will not get synthetic publish notifications by default. The notifications from the synthetic publishes will only be exposed if the INTERNAL_UNSTABLE policy is set.
This does not affect the actual monitoring checks performed by PAM because PAM checks the `notifications-rw` service directly passing the `monitor=true` query param.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-1966).

## Anything, in particular, you'd like to highlight to reviewers

Additionally to the task at hand I've added docker and compose files to speed up the running of tests locally. 

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
