### PR TITLE
Fix monitor query param issue

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
@@ -36,19 +36,23 @@ public class NotificationsTypeFilter implements ApiFilter {
     if (response.getStatus() != 200) {
       return response;
     }
+
     Map<String, Object> content = converter.readEntity(response);
     if (!typeCheckSucceeds(content)) {
       throw new FilterException(
           new IllegalStateException("Notifications json response is not in expected format."));
     }
 
-    stripTypeParam(content, REQUEST_URL_KEY);
+    stripInternalParams(content, REQUEST_URL_KEY);
+
     List links = (List) content.get(LINKS_KEY);
     if (links.isEmpty()) {
       converter.replaceEntity(response, content);
       return response;
     }
-    stripTypeParam((Map) links.get(0), HREF_KEY);
+
+    stripInternalParams((Map) links.get(0), HREF_KEY);
+
     converter.replaceEntity(response, content);
 
     return response;
@@ -71,9 +75,10 @@ public class NotificationsTypeFilter implements ApiFilter {
     request.getQueryParameters().put(MONITOR_KEY, monitorParams);
   }
 
-  private void stripTypeParam(Map<String, Object> content, String key) {
+  private void stripInternalParams(Map<String, Object> content, String key) {
     UriBuilder uriBuilder = UriBuilder.fromUri((String) content.get(key));
     uriBuilder.replaceQueryParam(TYPE_KEY, null);
+    uriBuilder.replaceQueryParam(MONITOR_KEY, null);
     content.put(key, uriBuilder.build());
   }
 

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
@@ -17,6 +17,7 @@ public class NotificationsTypeFilter implements ApiFilter {
   private static final String LINKS_KEY = "links";
   private static final String HREF_KEY = "href";
   private static final String TYPE_KEY = "type";
+  private static final String MONITOR_KEY = "monitor";
 
   private JsonConverter converter;
   private Policy policy;
@@ -63,7 +64,11 @@ public class NotificationsTypeFilter implements ApiFilter {
     }
 
     request.getQueryParameters().put(TYPE_KEY, typeParams);
-    request.getQueryParameters().putSingle("monitor", String.valueOf(hasRequiredPolicy));
+
+    List<String> monitorParams = new ArrayList<>();
+    monitorParams.add(String.valueOf(hasRequiredPolicy));
+
+    request.getQueryParameters().put(MONITOR_KEY, monitorParams);
   }
 
   private void stripTypeParam(Map<String, Object> content, String key) {

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
@@ -33,9 +33,9 @@ public class NotificationsTypeFilterTest {
   public static final String ERROR_RESPONSE = "{ \"message\" : \"Error\" }";
   public static final String SUCCESS_RESPONSE =
       "{ \"requestUrl\":"
-          + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\","
+          + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource&monitor=false\","
           + " \"links\": [ {\"href\":"
-          + " \"http://example.org/content/100?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\","
+          + " \"http://example.org/content/100?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource&monitor=false\","
           + " \"rel\" : \"next\"}] }";
   public static final String STRIPPED_SUCCESS_RESPONSE =
       "{\"requestUrl\":\"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z\",\"links\":[{\"href\":\"http://example.org/content/100?since=2016-07-23T00:00:00.000Z\",\"rel\":\"next\"}]}";
@@ -178,7 +178,7 @@ public class NotificationsTypeFilterTest {
 
     String responseBody =
         "{ \"requestUrl\":"
-            + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource\","
+            + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource&monitor=false\","
             + " \"links\": [] }";
     String strippedBody =
         "{\"requestUrl\":\"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z\",\"links\":[]}";

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
@@ -3,7 +3,6 @@ package com.ft.up.apipolicy.filters;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -116,7 +115,7 @@ public class NotificationsTypeFilterTest {
 
     filter.processRequest(request, chain);
 
-    verify(params).putSingle("monitor", "true");
+    verify(params).put("monitor", Collections.singletonList("true"));
   }
 
   @Test
@@ -128,7 +127,7 @@ public class NotificationsTypeFilterTest {
 
     filter.processRequest(request, chain);
 
-    verify(params).putSingle("monitor", "false");
+    verify(params).put("monitor", Collections.singletonList("false"));
   }
 
   @Test
@@ -141,7 +140,7 @@ public class NotificationsTypeFilterTest {
 
     filter.processRequest(request, chain);
 
-    assertEquals("false", params.getFirst("monitor"));
+    assertThat(params.get("monitor"), equalTo(Collections.singletonList("false")));
   }
 
   @Test


### PR DESCRIPTION
# Description

## What

Fixing issue with 500 Server error when there is a `monitor` query param present in the request URL.
The bug was due to the usage of an unsupported `putSingle` method on an underlying type of the `MultivaluedMap` interface.
The reason for getting the `monitor` query param in the first place was because we have missed to strip the param from the response body for getting notifications.
Now test requests like `GET https://{{delivery_host}}/content/notifications?monitor=false&since=2021-01-11T00:05:00.345Z` should not be failing and there should not be `monitor` query param present in the `requestUrl` and `href` under `links` values.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-2014).

## Anything, in particular, you'd like to highlight to reviewers

The release candidate is deployed on Staging.
I will close the pending https://github.com/Financial-Times/api-policy-component/pull/74 and https://github.com/Financial-Times/notifications-rw/pull/34 revert PRs because this PR should address the issue.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [X] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
