### PR TITLE
Use docker multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN apk --update add git maven curl \
   && rm -rf /var/cache/apk/* \
   && rm -rf $MAVEN_HOME/*
 
+FROM openjdk:8u212-jdk-alpine3.9
+COPY --from=0 /api-policy-component-service.jar /api-policy-component-service.jar
+COPY --from=0 /config.yml /config.yml
+
 EXPOSE 8080 8081
 
 CMD exec java $JAVA_OPTS \

--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -18,24 +18,6 @@ Platinum
 
 Production
 
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- elitsa.pavlova
-- hristo.georgiev
-- dimitar.terziev
-- georgi.ivanov
-- tsvetan.dimitrov
-- robert.marinov
-- elina.kaneva
-
 ## Host Platform
 
 AWS


### PR DESCRIPTION
# Description

## What

Implement Docker multistage build.
Fix runbook.

## Why

So that we don't leak credentials that are needed only for build stage in DockerHub.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
