### PR TITLE
Adding content type field for notifications pull.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,10 +10,24 @@ workflows:
 jobs:
   build:
     docker:
-      - image:  docker:stable-git
+      - image: cimg/openjdk:8.0
     steps:
       - checkout
       - setup_remote_docker
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "pom.xml" }}
+            - v1-dependencies-
+      - run:
+          name: Build package, run tests and upload test coverage
+          command: |
+            mkdir -p ~/.m2/
+            curl -v -o ~/.m2/settings.xml "https://raw.githubusercontent.com/Financial-Times/nexus-settings/master/public-settings.xml"
+            mvn clean package jacoco:report-aggregate coveralls:report -Djava.net.preferIPv4Stack=true -DrepoToken=${COVERALLS_TOKEN}
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "pom.xml" }}
       - run:
           name: Set Docker image tag based on branch or git tag
           command: |
@@ -33,10 +47,3 @@ jobs:
             --build-arg SONATYPE_PASSWORD=${SONATYPE_PASSWORD} \
             --build-arg GIT_TAG=${DOCKER_TAG} \
             --tag nexus.in.ft.com:5000/coco/${CIRCLE_PROJECT_REPONAME}:${DOCKER_TAG} .
-      - deploy:
-          name: Push Docker image
-          command: |
-            source ${BASH_ENV}
-            docker login nexus.in.ft.com:5000 -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
-            docker push nexus.in.ft.com:5000/coco/${CIRCLE_PROJECT_REPONAME}:${DOCKER_TAG}
-            

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,7 @@
 Api Policy Component
 ====================
 [![CircleCI](https://circleci.com/gh/Financial-Times/api-policy-component.svg?style=shield)](https://circleci.com/gh/Financial-Times/api-policy-component)
+[![Coverage Status](https://coveralls.io/repos/github/Financial-Times/api-policy-component/badge.svg?branch=master)](https://coveralls.io/github/Financial-Times/api-policy-component?branch=master)
 
 An HTTP service provides a facade over the reader endpoint for use by licenced partners.
 

--- a/api-policy-component-service/pom.xml
+++ b/api-policy-component-service/pom.xml
@@ -11,7 +11,6 @@
   <url>http://www.ft.com</url>
   <inceptionYear>2014</inceptionYear>
   <properties>
-    <surefire.reportplugin.version>2.22.2</surefire.reportplugin.version>
     <maven-jar-plugin.version>2.3.2</maven-jar-plugin.version>
     <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
     <maven-shade-plugin.version>.</maven-shade-plugin.version>
@@ -25,8 +24,8 @@
     <maven-jxr-plugin.version>2.3</maven-jxr-plugin.version>
     <target-jdk>1.8</target-jdk>
     <mockito-core.version>1.9.5</mockito-core.version>
-    <jacoco-maven-plugin.version>0.7.4.201502262128</jacoco-maven-plugin.version>
     <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
+    <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
   </properties>
   <dependencies>
     <dependency>
@@ -195,25 +194,25 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>${jacoco-maven-plugin.version}</version>
-        <executions>
-          <execution>
-            <id>prepare-agent</id>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>report</goal>
-            </goals>
-          </execution>
-        </executions>
+       <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco-maven-plugin.version}</version>
+            <executions>
+                <execution>
+                    <id>prepare-agent</id>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>report</id>
+                    <phase>prepare-package</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                </execution>
+            </executions>
       </plugin>
       <plugin>
         <artifactId>maven-pmd-plugin</artifactId>
@@ -368,13 +367,6 @@
       <plugin>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>${checkstyle.version}</version>
-      </plugin>
-      <plugin>
-        <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>${surefire.reportplugin.version}</version>
-        <configuration>
-          <useSystemClassLoader>false</useSystemClassLoader>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-pmd-plugin</artifactId>

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
@@ -133,6 +133,10 @@ public class ApiFilters {
   }
 
   public ApiFilter notificationsFilter() {
+    return new PolicyBasedJsonFilter(notificationsFiltersMap());
+  }
+
+  private Map<String, Policy> notificationsFiltersMap() {
     Map<String, Policy> notificationsJsonFilters = new HashMap<>();
     // whitelisted (no policy required)
     notificationsJsonFilters.put("$.requestUrl", null);
@@ -145,7 +149,7 @@ public class ApiFilters {
     notificationsJsonFilters.put("$.notifications[*].notificationDate", INCLUDE_LAST_MODIFIED_DATE);
     notificationsJsonFilters.put("$.notifications[*].publishReference", INCLUDE_PROVENANCE);
 
-    return new PolicyBasedJsonFilter(notificationsJsonFilters);
+    return notificationsJsonFilters;
   }
 
   public ApiFilter[] listsFilters() {
@@ -228,7 +232,12 @@ public class ApiFilters {
   }
 
   public ApiFilter[] contentNotificationsFilters() {
-    return new ApiFilter[] {mediaResourceNotificationsFilter, brandFilter, notificationsFilter()};
+    Map<String, Policy> notificationsFilters = notificationsFiltersMap();
+    notificationsFilters.put("$.notifications[*].contentType", INTERNAL_UNSTABLE);
+
+    return new ApiFilter[] {
+      mediaResourceNotificationsFilter, brandFilter, new PolicyBasedJsonFilter(notificationsFilters)
+    };
   }
 
   public ApiFilter[] contentIdentifiersFilters() {

--- a/docker-compose-tests.yml
+++ b/docker-compose-tests.yml
@@ -10,4 +10,4 @@ services:
       SONATYPE_PASSWORD: ${SONATYPE_PASSWORD}
     volumes:
       - ~/.m2/repository:/root/.m2/repository
-    command: ["mvn", "test"]
+    command: ["mvn", "test", "clean", "package", "jacoco:report", "coveralls:report"]

--- a/pom.xml
+++ b/pom.xml
@@ -9,4 +9,53 @@
     <module>api-policy-component-service</module>
     <module>api-policy-component-json-schema</module>
   </modules>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
+    <coveralls-maven-plugin.version>4.3.0</coveralls-maven-plugin.version>
+  </properties>
+  <build>
+    <finalName>ParentPOM</finalName>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.jacoco</groupId>
+          <artifactId>jacoco-maven-plugin</artifactId>
+          <version>${jacoco-maven-plugin.version}</version>
+          <executions>
+            <execution>
+                <id>prepare-agent</id>
+                <goals>
+                    <goal>prepare-agent</goal>
+                </goals>
+            </execution>
+            <execution>
+                <id>report</id>
+                <phase>prepare-package</phase>
+                <goals>
+                    <goal>report</goal>
+                </goals>
+             </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.eluder.coveralls</groupId>
+          <artifactId>coveralls-maven-plugin</artifactId>
+          <version>${coveralls-maven-plugin.version}</version>
+          <configuration>
+	    	<jacocoReports>
+	    		<jacocoReport>${project.basedir}/api-policy-component-service/target/site/jacoco/jacoco.xml</jacocoReport>
+	    	</jacocoReports>
+	      </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>javax.xml.bind</groupId>
+              <artifactId>jaxb-api</artifactId>
+              <version>2.3.1</version>
+            </dependency>
+          </dependencies>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>


### PR DESCRIPTION
# Description

## What

Allowing the `contentType` field in the response of pull notifications to be visible for `INTERNAL_UNSTABLE` policies.

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-2897)

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g


## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
