### PR TITLE
Added `subType` to notifications filters.

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
@@ -148,6 +148,7 @@ public class ApiFilters {
     notificationsJsonFilters.put("$.links[*].*", null);
     notificationsJsonFilters.put("$.notifications[*].id", null);
     notificationsJsonFilters.put("$.notifications[*].type", null);
+    notificationsJsonFilters.put("$.notifications[*].subType", null);
     notificationsJsonFilters.put("$.notifications[*].apiUrl", null);
     // restricted (policy required)
     notificationsJsonFilters.put("$.notifications[*].lastModified", INCLUDE_LAST_MODIFIED_DATE);


### PR DESCRIPTION
# Description

## What

Adds a new attribute to the validation schema.

## Why

As requested by the Spark team https://github.com/Financial-Times/content-platform/issues/32, the type field enum currently contains a single value only (Page). We need to rename it to HomePage and add HubPage to cover the new use case of differentiating between the home page and the hub page.

https://financialtimes.atlassian.net/browse/UPPSF-3553

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
