### PR TITLE
Added filter for summary into `INCLUDE_BODY_TREE` policy.

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
@@ -24,6 +24,7 @@ public class ApiFilters {
   private static final String LAST_MODIFIED_JSON_PROPERTY = "lastModified";
   private static final String LITE_JSON_PROPERTY = "lite";
   private static final String BODY_TREE_JSON_PROPERTY = "bodyTree";
+  private static final String SUMMARY_BODY_TREE_JSON_PROPERTY = "summary.bodyTree";
   private static final String OPENING_XML_JSON_PROPERTY = "openingXML";
   private static final String ACCESS_LEVEL_JSON_PROPERTY = "accessLevel";
   private static final String CONTENT_PACKAGE_CONTAINS_JSON_PROPERTY = "contains";
@@ -49,6 +50,7 @@ public class ApiFilters {
   private ApiFilter stripLastModifiedDate;
   private ApiFilter stripLite;
   private ApiFilter stripBodyTree;
+  private ApiFilter stripSummaryBodyTree;
   private ApiFilter stripOpeningXml;
   private ApiFilter linkValidationFilter;
   private ApiFilter mediaResourceNotificationsFilter;
@@ -103,6 +105,9 @@ public class ApiFilters {
     stripBodyTree =
         new RemoveJsonPropertiesUnlessPolicyPresentFilter(
             jsonTweaker, INCLUDE_BODY_TREE, BODY_TREE_JSON_PROPERTY);
+    stripSummaryBodyTree =
+        new RemoveJsonNestedPropertiesUnlessPolicyPresentFilter(
+            jsonTweaker, INCLUDE_BODY_TREE, SUMMARY_BODY_TREE_JSON_PROPERTY);
     stripOpeningXml =
         new RemoveJsonPropertiesUnlessPolicyPresentFilter(
             jsonTweaker, INTERNAL_UNSTABLE, OPENING_XML_JSON_PROPERTY);
@@ -185,6 +190,7 @@ public class ApiFilters {
       stripLastModifiedDate,
       stripLite,
       stripBodyTree,
+      stripSummaryBodyTree,
       stripOpeningXml,
       accessLevelPropertyFilter,
       accessLevelHeaderFilter,

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/RemoveJsonNestedPropertiesUnlessPolicyPresentFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/RemoveJsonNestedPropertiesUnlessPolicyPresentFilter.java
@@ -1,0 +1,39 @@
+package com.ft.up.apipolicy.filters;
+
+import com.ft.up.apipolicy.JsonConverter;
+import com.ft.up.apipolicy.configuration.Policy;
+import com.ft.up.apipolicy.pipeline.MutableRequest;
+import java.util.Map;
+
+public class RemoveJsonNestedPropertiesUnlessPolicyPresentFilter
+    extends SuppressJsonPropertiesFilter {
+
+  private final Policy policy;
+
+  public RemoveJsonNestedPropertiesUnlessPolicyPresentFilter(
+      final JsonConverter jsonConverter, final Policy policy, final String... jsonProperties) {
+    super(jsonConverter, jsonProperties);
+    this.policy = policy;
+  }
+
+  @Override
+  protected boolean shouldPropertyFilteredOut(
+      final String jsonProperty, final MutableRequest request, Map content) {
+    return !request.policyIs(policy);
+  }
+
+  @Override
+  protected void removeProperty(Map contentModel, String jsonProp) {
+    Map temp = contentModel;
+    String[] path = jsonProp.split("\\.");
+    for (int i = 0; i < path.length - 1; i++) {
+      Object step = temp.get(path[i]);
+      if (!(step instanceof Map)) {
+        // nested key invalid or not found
+        return;
+      }
+      temp = (Map) step;
+    }
+    temp.remove(path[path.length - 1]);
+  }
+}

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/SuppressJsonPropertiesFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/SuppressJsonPropertiesFilter.java
@@ -78,7 +78,7 @@ public class SuppressJsonPropertiesFilter extends AbstractImageFilter {
     FieldModifier modifier =
         (jsonProp, contentModel) -> {
           if (shouldPropertyFilteredOut(jsonProp, request, contentModel)) {
-            contentModel.remove(jsonProp);
+            removeProperty(contentModel, jsonProp);
             jsonConverter.replaceEntity(response, content);
           }
         };
@@ -89,5 +89,9 @@ public class SuppressJsonPropertiesFilter extends AbstractImageFilter {
   protected boolean shouldPropertyFilteredOut(
       final String jsonProperty, MutableRequest request, final Map content) {
     return content.containsKey(jsonProperty);
+  }
+
+  protected void removeProperty(Map contentModel, String jsonProp) {
+    contentModel.remove(jsonProp);
   }
 }

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentContentEndpointsRestrictedPropertiesTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentContentEndpointsRestrictedPropertiesTest.java
@@ -104,6 +104,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
           + ",\n"
           + "\"brands\": [ ],\n"
           + "\"annotations\": [ ],\n"
+          + "\"summary\": { \"bodyTree\": {  } },"
           + "\"lite\": { }"
           + "}";
 


### PR DESCRIPTION
# Description

## What

Adding the `INCLUDE_BODY_TREE` policy to `bodyTree` inside `summary`. 

## Why

[JIRA ticket](https://financialtimes.atlassian.net/browse/UPPSF-4133).

## Anything, in particular, you'd like to highlight to reviewers

Existing filters were designed to remove rootLevel properties or in [this case](https://github.com/Financial-Times/api-policy-component/blob/master/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/PolicyBasedJsonFilter.java) which works with `JSON path` I´d have to `whitelist` each property and `blacklist` `$.summary.bodyTree`. For sake of simplicity create a new filter for this particular case IMO is the best option.

Changes can be tested in `staging` with this uuid: `de8d4ce0-0d24-4107-8c35-57ddd2f8ffdb`

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [X] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
