### PR TITLE
Adding cm-live-events-api to the api policies

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/ApiPolicyApplication.java
@@ -174,6 +174,13 @@ public class ApiPolicyApplication extends Application<ApiPolicyConfiguration> {
             apiFilters.contentPreviewFilters()));
     knownWildcardEndpoints.add(
         createEndpoint(environment, configuration, "^/concordances.*", "concordances"));
+    knownWildcardEndpoints.add(
+        createEndpoint(
+            environment,
+            configuration,
+            "^/live-events.*",
+            "live-events",
+            apiFilters.liveEventsFilter()));
     // DEFAULT CASE: Just forward it
     knownWildcardEndpoints.add(createEndpoint(environment, configuration, "^/.*", "other"));
 

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
@@ -298,4 +298,14 @@ public class ApiFilters {
       internalAnalyticsTagsFilter
     };
   }
+
+  public ApiFilter[] liveEventsFilter() {
+    return new ApiFilter[] {
+      stripProvenance,
+      stripLastModifiedDate,
+      identifiersFilter,
+      alternativeStandfirstsFilter,
+      alternativeTitlesFilter
+    };
+  }
 }


### PR DESCRIPTION
# Description

## What

Adding the /live-events endpoint.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4173

## Anything, in particular, you'd like to highlight to reviewers

I've added the `publishReference` and `lastModified` field filters, since they seem to be the only ones which are "service" fields in the response. One thought that I had is that the Community team has had access to those fields when testing the API, since they tested directly through the service. We can add the respective x-policies to their API key when generating one if they need it.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
