### PR TITLE
Do not filter MainImage objects if they are in a live event

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/AbstractImageFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/AbstractImageFilter.java
@@ -9,10 +9,18 @@ import org.apache.http.HttpStatus;
 
 public abstract class AbstractImageFilter implements ApiFilter {
 
+  private static final String LIVE_EVENT_TYPE = "http://www.ft.com/ontology/content/LiveEvent";
+
   protected void applyFilter(String jsonProperty, FieldModifier modifier, Map content) {
     modifier.operation(jsonProperty, content);
     Object mainImageSet = content.get(MAIN_IMAGE);
-    if (mainImageSet instanceof Map) {
+
+    String contentType = "";
+    if (content.containsKey(CONTENT_TYPE)) {
+      contentType = content.get(CONTENT_TYPE).toString();
+    }
+
+    if (mainImageSet instanceof Map && !contentType.equals(LIVE_EVENT_TYPE)) {
       Map mainImageSetAsMap = (Map) mainImageSet;
       if (mainImageSetAsMap.size() > 1) {
         try {

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/pipeline/ApiFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/pipeline/ApiFilter.java
@@ -14,6 +14,7 @@ public interface ApiFilter {
   String MEMBERS = "members";
   String LEAD_IMAGES = "leadImages";
   String IMAGE = "image";
+  String CONTENT_TYPE = "type";
 
   MutableResponse processRequest(MutableRequest request, HttpPipelineChain chain);
 }


### PR DESCRIPTION
# Description

## What

This is an ugly solution, but this filter is for some reason applied in every filter chain for every request(even random ones like `/asdf123`). I could not find the reason behind this and where this is actually used, but it debugging more gets out of scope for this task.

## Why

https://financialtimes.atlassian.net/browse/UPPSF-4186

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
