### PR TITLE
Strip hideCreate param from responses

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/NotificationsTypeFilter.java
@@ -97,6 +97,7 @@ public class NotificationsTypeFilter implements ApiFilter {
     UriBuilder uriBuilder = UriBuilder.fromUri((String) content.get(key));
     uriBuilder.replaceQueryParam(TYPE_KEY, null);
     uriBuilder.replaceQueryParam(MONITOR_KEY, null);
+    uriBuilder.replaceQueryParam(HIDE_CREATE_EVENTS_KEY, null);
     content.put(key, uriBuilder.build());
   }
 

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/filters/NotificationsTypeFilterTest.java
@@ -186,7 +186,7 @@ public class NotificationsTypeFilterTest {
 
     String responseBody =
         "{ \"requestUrl\":"
-            + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource&monitor=false\","
+            + " \"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z&type=article&type=mediaResource&monitor=false&hideCreate=true\","
             + " \"links\": [] }";
     String strippedBody =
         "{\"requestUrl\":\"http://example.org/content/notifications?since=2016-07-23T00:00:00.000Z\",\"links\":[]}";


### PR DESCRIPTION
# Description

## What

Removes the `hideCreate` parameter from responses of the Notifications API.

## Why

[JIRA Ticket](https://financialtimes.atlassian.net/browse/UPPSF-4306)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
