### PR TITLE
Stripping isTestContent json filed

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
@@ -20,6 +20,7 @@ public class ApiFilters {
   private static final String IDENTIFIERS_JSON_PROPERTY = "identifiers";
   private static final String ALT_TITLES_JSON_PROPERTY = "alternativeTitles";
   private static final String ALT_IMAGES_JSON_PROPERTY = "alternativeImages";
+  private static final String IS_TEST_CONTENT_JSON_PROPERTY = "alternativeImages";
   private static final String ALT_STANDFIRST_JSON_PROPERTY = "alternativeStandfirsts";
   private static final String COMMENTS_JSON_PROPERTY = "comments";
   private static final String PROVENANCE_JSON_PROPERTY = "publishReference";
@@ -38,6 +39,7 @@ public class ApiFilters {
   private ApiFilter identifiersFilter;
   private ApiFilter alternativeTitlesFilter;
   private ApiFilter alternativeImagesFilter;
+  private ApiFilter isTestContentFilter;
   private ApiFilter alternativeStandfirstsFilter;
   private ApiFilter stripCommentsFields;
   private ApiFilter removeCommentsFieldRegardlessOfPolicy;
@@ -83,6 +85,9 @@ public class ApiFilters {
     alternativeImagesFilter =
         new RemoveJsonPropertiesUnlessPolicyPresentFilter(
             jsonTweaker, Collections.singleton(INTERNAL_UNSTABLE), ALT_IMAGES_JSON_PROPERTY);
+    isTestContentFilter =
+        new RemoveJsonPropertiesUnlessPolicyPresentFilter(
+            jsonTweaker, Collections.singleton(INTERNAL_UNSTABLE), IS_TEST_CONTENT_JSON_PROPERTY);
     alternativeStandfirstsFilter =
         new RemoveJsonPropertiesUnlessPolicyPresentFilter(
             jsonTweaker, Collections.singleton(INTERNAL_UNSTABLE), ALT_STANDFIRST_JSON_PROPERTY);
@@ -187,6 +192,7 @@ public class ApiFilters {
       mainImageFilter,
       alternativeTitlesFilter,
       alternativeImagesFilter,
+      isTestContentFilter,
       alternativeStandfirstsFilter,
       stripCommentsFields,
       stripProvenance,
@@ -212,6 +218,7 @@ public class ApiFilters {
       mainImageFilter,
       alternativeTitlesFilter,
       alternativeImagesFilter,
+      isTestContentFilter,
       alternativeStandfirstsFilter,
       stripCommentsFields,
       stripProvenance,
@@ -237,6 +244,7 @@ public class ApiFilters {
       mainImageFilter,
       alternativeTitlesFilter,
       alternativeImagesFilter,
+      isTestContentFilter,
       alternativeStandfirstsFilter,
       stripCommentsFields,
       stripProvenance,
@@ -276,6 +284,7 @@ public class ApiFilters {
       mainImageFilter,
       alternativeTitlesFilter,
       alternativeImagesFilter,
+      isTestContentFilter,
       alternativeStandfirstsFilter,
       removeCommentsFieldRegardlessOfPolicy,
       stripProvenance,
@@ -298,6 +307,7 @@ public class ApiFilters {
       mainImageFilter,
       alternativeTitlesFilter,
       alternativeImagesFilter,
+      isTestContentFilter,
       alternativeStandfirstsFilter,
       stripCommentsFields,
       stripProvenance,

--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/configuration/ApiFilters.java
@@ -20,7 +20,7 @@ public class ApiFilters {
   private static final String IDENTIFIERS_JSON_PROPERTY = "identifiers";
   private static final String ALT_TITLES_JSON_PROPERTY = "alternativeTitles";
   private static final String ALT_IMAGES_JSON_PROPERTY = "alternativeImages";
-  private static final String IS_TEST_CONTENT_JSON_PROPERTY = "alternativeImages";
+  private static final String IS_TEST_CONTENT_JSON_PROPERTY = "isTestContent";
   private static final String ALT_STANDFIRST_JSON_PROPERTY = "alternativeStandfirsts";
   private static final String COMMENTS_JSON_PROPERTY = "comments";
   private static final String PROVENANCE_JSON_PROPERTY = "publishReference";

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentContentEndpointsRestrictedPropertiesTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentContentEndpointsRestrictedPropertiesTest.java
@@ -74,6 +74,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
           + "\"alternativeTitles\" : {},\n"
           + "\"alternativeImages\" : {},\n"
           + "\"alternativeStandfirsts\" : {},\n"
+          + "\"isTestContent\": \"true\",\n"
           + "\"lastModified\": \"2015-12-13T17:04:54.636Z\",\n"
           + "\"publishReference\": \"tid_junit_publishref\",\n"
           + "\"identifiers\": [{\n"
@@ -218,6 +219,17 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
           },
           {
             "openingXML",
+            Policy.INTERNAL_UNSTABLE,
+            true,
+            true,
+            true,
+            true,
+            CONTENT_JSON,
+            ENRICHED_CONTENT_JSON,
+            INTERNAL_CONTENT_JSON
+          },
+          {
+            "isTestContent",
             Policy.INTERNAL_UNSTABLE,
             true,
             true,
@@ -398,7 +410,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldAllowPropertyForContentWhenPolicyIsPresent() throws Exception {
+  public void shouldAllowPropertyForContentWhenPolicyIsPresent() {
     final URI uri = fromFacade(CONTENT_PATH).build();
     response =
         client
@@ -411,7 +423,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldAllowPropertyForContentPreviewWhenPolicyIsPresent() throws Exception {
+  public void shouldAllowPropertyForContentPreviewWhenPolicyIsPresent() {
     final URI uri = fromFacade(CONTENT_PREVIEW_PATH).build();
     response =
         client
@@ -424,7 +436,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldAllowPropertyForEnrichedContentWhenPolicyIsPresent() throws Exception {
+  public void shouldAllowPropertyForEnrichedContentWhenPolicyIsPresent() {
     final URI uri = fromFacade(ENRICHED_CONTENT_PATH).build();
     response =
         client
@@ -437,7 +449,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldAllowPropertyForInternalContentWhenPolicyIsPresent() throws Exception {
+  public void shouldAllowPropertyForInternalContentWhenPolicyIsPresent() {
     final URI uri = fromFacade(INTERNAL_CONTENT_PATH).build();
     response =
         client
@@ -450,7 +462,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldRemovePropertyForContentWhenPolicyIsNotPresent() throws Exception {
+  public void shouldRemovePropertyForContentWhenPolicyIsNotPresent() {
     final URI uri = fromFacade(CONTENT_PATH).build();
     response = client.target(uri).request().get();
 
@@ -458,7 +470,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldRemovePropertyForContentPreviewWhenPolicyIsNotPresent() throws Exception {
+  public void shouldRemovePropertyForContentPreviewWhenPolicyIsNotPresent() {
     final URI uri = fromFacade(CONTENT_PREVIEW_PATH).build();
     response = client.target(uri).request().get();
 
@@ -466,7 +478,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldRemovePropertyForEnrichedContentWhenPolicyIsNotPresent() throws Exception {
+  public void shouldRemovePropertyForEnrichedContentWhenPolicyIsNotPresent() {
     final URI uri = fromFacade(ENRICHED_CONTENT_PATH).build();
     response = client.target(uri).request().get();
 
@@ -474,7 +486,7 @@ public class ApiPolicyComponentContentEndpointsRestrictedPropertiesTest
   }
 
   @Test
-  public void shouldRemovePropertyForInternalContentWhenPolicyIsNotPresent() throws Exception {
+  public void shouldRemovePropertyForInternalContentWhenPolicyIsNotPresent() {
     final URI uri = fromFacade(INTERNAL_CONTENT_PATH).build();
     response = client.target(uri).request().get();
 

--- a/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentHappyPathsTest.java
+++ b/api-policy-component-service/src/test/java/com/ft/up/apipolicy/ApiPolicyComponentHappyPathsTest.java
@@ -191,6 +191,7 @@ public class ApiPolicyComponentHappyPathsTest extends AbstractApiComponentTest {
           + "\"brands\": [ ],\n"
           + "\"annotations\": [ ], \n"
           + "\"accessLevel\": \"subscribed\",\n"
+          + "\"isTestContent\": \"true\",\n"
           + "\"contains\": [\"http://api.ft.com/things/111192a7-1f0c-11e4-b0cb-b2227cce2b54\"],\n"
           + "\"containedIn\": [\"http://api.ft.com/things/4c7592a7-1f0c-11e4-b0cb-b2227cce2b54\"]\n"
           + "}";
@@ -924,6 +925,7 @@ public class ApiPolicyComponentHappyPathsTest extends AbstractApiComponentTest {
       String jsonPayload = response.readEntity(String.class);
       assertThat(jsonPayload, containsJsonProperty("containedIn"));
       assertThat(jsonPayload, containsJsonProperty("contains"));
+      assertThat(jsonPayload, containsJsonProperty("isTestContent"));
     } finally {
       response.close();
     }


### PR DESCRIPTION
# Description

## What

Stripping isTestContent json filed when we have **INTERNAL_UNSTABLE** x-policy

## Why

JIRA -> https://financialtimes.atlassian.net/browse/UPPSF-4506

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [ ] Test coverage is not significantly decreased
- [ ] All PR checks have passed
- [ ] Changes are deployed on dev before asking for review
- [ ] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
