### PR TITLE
UPPSF-5325 Omit Rich Content Strip in case of CCC

### DIFF
--- a/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/SuppressRichContentMarkupFilter.java
+++ b/api-policy-component-service/src/main/java/com/ft/up/apipolicy/filters/SuppressRichContentMarkupFilter.java
@@ -19,6 +19,11 @@ public class SuppressRichContentMarkupFilter implements ApiFilter {
   private final JsonConverter jsonConverter;
   private BodyProcessingFieldTransformer transformer;
 
+  private static final String TYPE_FIELD = "type";
+
+  private static final String CUSTOM_CODE_COMPONENT_CLASS_URI =
+      "http://www.ft.com/ontology/content/CustomCodeComponent";
+
   public SuppressRichContentMarkupFilter(
       JsonConverter jsonConverter, BodyProcessingFieldTransformer transformer) {
     this.jsonConverter = jsonConverter;
@@ -39,6 +44,13 @@ public class SuppressRichContentMarkupFilter implements ApiFilter {
     }
 
     Map<String, Object> content = jsonConverter.readEntity(response);
+
+    if (content.get(TYPE_FIELD) != null
+        && content.get(TYPE_FIELD).equals(CUSTOM_CODE_COMPONENT_CLASS_URI)) {
+      // In case of CustomCodeComponent skip stripping bodyXML rich content
+      // regardless of INCLUDE_RICH_CONTENT policy
+      return response;
+    }
 
     for (String key : XML_KEYS) {
       String xml = (String) content.get(key);


### PR DESCRIPTION
# Description

## What

Skip stripping of rich content from the bodyXML in case of CustomCodeComponent

## Why

https://financialtimes.atlassian.net/browse/UPPSF-5325

## Anything, in particular, you'd like to highlight to reviewers

Mention here sections of code which you would like reviewers to pay extra attention to .E.g

_Would appreciate a second pair of eyes on the implementation_
_I am not quite sure how this bit works_

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

## DoD - Ensure all relevant tasks are completed before marking this PR as "Ready for review"

- [x] Test coverage is not significantly decreased
- [x] All PR checks have passed
- [x] Changes are deployed on dev before asking for review
- [x] Documentations remains up-to-date
  - [ ] OpenAPI definition file is updated
  - [ ] README file is updated
  - [ ] Documentation is updated in upp-docs and upp-public-docs
  - [ ] Architecture diagrams are updated

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
